### PR TITLE
Add ruby tls verfication script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+gem 'excon', '~> 0.49.0'
+gem 'httpclient', '~> 2.7.1'
+gem 'curb', '~> 0.9.1'
+gem 'http', '~> 1.0', '>= 1.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    curb (0.9.1)
+    domain_name (0.5.20160310)
+      unf (>= 0.0.5, < 1.0.0)
+    excon (0.49.0)
+    http (1.0.4)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0)
+    httpclient (2.7.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  curb (~> 0.9.1)
+  excon (~> 0.49.0)
+  http (~> 1.0, >= 1.0.4)
+  httpclient (~> 2.7.1)
+
+BUNDLED WITH
+   1.11.2

--- a/tls_verify.rb
+++ b/tls_verify.rb
@@ -1,0 +1,55 @@
+require 'excon'
+require 'httpclient'
+require 'curl'
+require "openssl"
+require 'net/http'
+require 'http'
+require 'json'
+
+def net_http url
+  Net::HTTP.get URI(url)
+end
+
+def excon url
+  Excon.get url
+end
+
+def httpclient url
+  HTTPClient.get url
+end
+
+def curb url
+  Curl.get url
+end
+
+def httprb url
+  HTTP.get url
+end
+
+urls = {
+    revoked: 'https://revoked.grc.com/',
+    incomplete_chain: 'https://incomplete-chain.badssl.com/',
+    expired: 'https://qvica1g3-e.quovadisglobal.com/',
+    expired2: 'https://expired.badssl.com/',
+    self_signed: 'https://self-signed.badssl.com/',
+    bad_domain: 'https://wrong.host.badssl.com/',
+    bad_domain2: 'https://tv.eurosport.com/',
+    rc4: 'https://rc4.badssl.com/',
+    dh480: 'https://dh480.badssl.com/',
+    superfish: 'https://superfish.badssl.com/',
+    edellroot: 'https://edellroot.badssl.com/',
+    dsdtestprovider: 'https://dsdtestprovider.badssl.com/'
+}
+
+methods = [:excon, :net_http, :httpclient, :curb, :httprb]
+
+methods.each do |method|
+  urls.each do |name, url|
+    begin
+      send(method, url)
+      puts "Error expected for #{name} when using #{method}"
+    rescue Exception => e
+      # puts "Error occurred when using #{method} for #{name} at #{url}:"
+    end
+  end
+end


### PR DESCRIPTION
I did a similar study for ruby HTTP client libraries and I would like to add the script to this repository. :wink:

I basically compared 5 libraries:
- excon
- httpclient
- curb
- http.rb
- net/http

Libraries like Faraday and HTTParty are left out as they are wrappers of these 5 basic libraries.
